### PR TITLE
Handles errors due to Promise rejections

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -39,7 +39,7 @@ exports.register = (server, options, next) => {
         const response = request.response
 
         // only show `bad implementation` developer errors (status code 500)
-        if (response.isDeveloperError || (response.isBoom && response.output.payload.statusCode === 500)) {
+        if (response.isDeveloperError || (response.isBoom && response.output.statusCode === 500)) {
             const accept = request.raw.req.headers.accept
             const statusCode = response.output.payload.statusCode
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -39,7 +39,7 @@ exports.register = (server, options, next) => {
         const response = request.response
 
         // only show `bad implementation` developer errors (status code 500)
-        if (response.isDeveloperError) {
+        if (response.isDeveloperError || (response.isBoom && response.output.payload.statusCode === 500)) {
             const accept = request.raw.req.headers.accept
             const statusCode = response.output.payload.statusCode
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1483,15 +1483,6 @@
                 "joi": "10.6.0"
             }
         },
-        "string_decoder": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-            "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-            "dev": true,
-            "requires": {
-                "safe-buffer": "5.1.1"
-            }
-        },
         "string-width": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -1517,6 +1508,15 @@
                         "ansi-regex": "3.0.0"
                     }
                 }
+            }
+        },
+        "string_decoder": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+            "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "5.1.1"
             }
         },
         "strip-ansi": {


### PR DESCRIPTION
First off, this a very nice plugin. Thank you!

It wouldn't work for me though, because I use Promises with most of my replies. After a bit of digging I found that `response.isDeveloperError` doesn't get set because promise rejects are wrapped in Boom objects. You therefore have to also check `response.isBoom` to capture Promise rejections.

BTW, I change from `lab.before` to `lab.beforeEach` in the test file because the test I added would timeout with a node `UnhandledPromiseRejectionWarning` otherwise.

Thanks again, and keeps those Hapi posts coming.

