### PR TITLE
feat: detect CLI requests and fallback to json response

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -36,6 +36,9 @@ function register (server, options) {
   // read and keep the default error template
   const errorTemplate = Fs.readFileSync(TemplatePath, 'utf8')
 
+  // helper function to test if string matches a value
+  const matches = (str, regex) => str && str.match(regex)
+
   // extend the request lifecycle at `onPreResponse`
   // to change the default error handling behavior (if enabled)
   server.ext('onPreResponse', async (request, h) => {
@@ -45,6 +48,7 @@ function register (server, options) {
     // only show `bad implementation` developer errors (status code 500)
     if (error.isBoom && error.output.statusCode === 500) {
       const accept = request.raw.req.headers.accept
+      const agent = request.raw.req.headers['user-agent']
       const statusCode = error.output.statusCode
 
       const errorResponse = {
@@ -58,8 +62,8 @@ function register (server, options) {
         stacktrace: error.stack.replace(/[a-z_-\d]+.js:\d+:\d+/gi, '<mark>$&</mark>')
       }
 
-      // take priority: check header if there’s a JSON REST request
-      if (accept && accept.match(/json/)) {
+      // take priority: check header if there’s a JSON REST request or request is in CLI
+      if (matches(accept, /json/) || matches(agent, /curl|wget/i)) {
         return h.response(errorResponse).code(statusCode)
       }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -62,8 +62,17 @@ function register (server, options) {
         stacktrace: error.stack.replace(/[a-z_-\d]+.js:\d+:\d+/gi, '<mark>$&</mark>')
       }
 
-      // take priority: check header if there’s a JSON REST request or request is in CLI
-      if (matches(accept, /json/) || matches(agent, /curl|wget/i)) {
+      // take priority: check header if request is in CLI
+      if (matches(agent, /curl|wget|postman/i)) {
+        const formattedJSON = JSON.stringify(Object.assign({}, errorResponse, {
+          stacktrace: errorResponse.stacktrace.replace(/<\/?mark>/g, '').split('\n').map(s => s.trim())
+        }), null, 2)
+
+        return h.response(formattedJSON).code(statusCode).type('application/json')
+      }
+
+      // take priority: check header if there’s a JSON REST request
+      if (matches(accept, /json/)) {
         return h.response(errorResponse).code(statusCode)
       }
 

--- a/test/plugin-falls-back-to-json.js
+++ b/test/plugin-falls-back-to-json.js
@@ -1,0 +1,62 @@
+'use strict'
+
+const Lab = require('lab')
+const Code = require('code')
+const Hapi = require('hapi')
+
+let server
+
+const { experiment, test, before } = (exports.lab = Lab.script())
+const expect = Code.expect
+
+experiment('hapi-dev-error falls back to json', () => {
+  before(async () => {
+    server = new Hapi.Server()
+
+    // fake dev env, no process.env.NODE_ENV defined
+    await server.register({
+      plugin: require('../lib/index'),
+      options: {
+        showErrors: true
+      }
+    })
+
+    const routeOptions = {
+      path: '/error',
+      method: 'GET',
+      handler: () => {
+        return new Error('Somethinng bad happened')
+      }
+    }
+
+    server.route(routeOptions)
+  })
+
+  test('test if the plugin responses json with json accept header', async () => {
+    const response = await server.inject({
+      url: '/error',
+      method: 'GET',
+      headers: {
+        accept: 'foobar json baz'
+      }
+    })
+    const payload = response.payload
+
+    expect(response.statusCode).to.equal(500)
+    expect(payload).to.startWith('{"')
+  })
+
+  test('test if the plugin responses json with curl user-agent', async () => {
+    const response = await server.inject({
+      url: '/error',
+      method: 'GET',
+      headers: {
+        'user-agent': 'curl/0.0'
+      }
+    })
+    const payload = response.payload
+
+    expect(response.statusCode).to.equal(500)
+    expect(payload).to.startWith('{"')
+  })
+})

--- a/test/plugin-falls-back-to-json.js
+++ b/test/plugin-falls-back-to-json.js
@@ -57,6 +57,6 @@ experiment('hapi-dev-error falls back to json', () => {
     const payload = response.payload
 
     expect(response.statusCode).to.equal(500)
-    expect(payload).to.startWith('{"')
+    expect(payload).to.startWith('{')
   })
 })


### PR DESCRIPTION
Hi! Thanks for this great project. Something annoying is that when testing API inside CLI environments with tools like `curl`, HTML response is really hard to read.

This PR adds a feature to detect CLI environments and use a prettier response.

Current status:

![image](https://user-images.githubusercontent.com/5158436/40588249-da8872da-61ef-11e8-8ca4-7637088f2579.png)

![image](https://user-images.githubusercontent.com/5158436/40588333-31c691f2-61f1-11e8-9264-b582c65fe57e.png)


With JSON:

![image](https://user-images.githubusercontent.com/5158436/40588252-e15c39ac-61ef-11e8-8dc3-797675ae17d0.png)

With formatted JSON (this PR):

![image](https://user-images.githubusercontent.com/5158436/40588321-058ff812-61f1-11e8-9fc5-8ac6947c7a4c.png)

![image](https://user-images.githubusercontent.com/5158436/40588377-cc049cb4-61f1-11e8-9d3e-a21620cff45e.png)
