### PR TITLE
Tests for checking is there is no accept content headers, plugin return HTML

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "eslint-plugin-node": "~6.0.1",
     "eslint-plugin-promise": "~3.8.0",
     "eslint-plugin-standard": "~3.1.0",
-    "hapi": "17.5.4",
+    "hapi": "~17.5.2",
     "husky": "~0.14.3",
     "joi": "^13.6.0",
     "lab": "~15.5.0",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,9 @@
     "eslint-plugin-node": "~6.0.1",
     "eslint-plugin-promise": "~3.8.0",
     "eslint-plugin-standard": "~3.1.0",
-    "hapi": "~17.5.2",
+    "hapi": "17.5.4",
     "husky": "~0.14.3",
+    "joi": "^13.6.0",
     "lab": "~15.5.0",
     "sinon": "~6.1.3",
     "vision": "~5.3.3"

--- a/test/failed-response-schema.js
+++ b/test/failed-response-schema.js
@@ -50,6 +50,19 @@ experiment('hapi-dev-error falls back to json', () => {
     })
 
     expect(response.statusCode).to.equal(500)
+    expect(response.headers['content-type']).to.equal('text/html; charset=utf-8')
+  })
+
+  test('test if the response schema failed and no specified header', async () => {
+    const response = await server.inject({
+      url: '/kind',
+      method: 'GET',
+      headers: {
+        accept: 'application/json'
+      }
+    })
+
+    expect(response.statusCode).to.equal(500)
     expect(response.headers['content-type']).to.equal('application/json; charset=utf-8')
   })
 })

--- a/test/failed-response-schema.js
+++ b/test/failed-response-schema.js
@@ -1,0 +1,55 @@
+'use strict'
+
+const Lab = require('lab')
+const Code = require('code')
+const Hapi = require('hapi')
+const Joi = require('joi')
+
+let server
+
+const { experiment, test, before } = (exports.lab = Lab.script())
+const expect = Code.expect
+
+experiment('hapi-dev-error falls back to json', () => {
+  before(async () => {
+    server = new Hapi.Server()
+
+    // fake dev env, no process.env.NODE_ENV defined
+    await server.register({
+      plugin: require('../lib/index'),
+      options: {
+        showErrors: true,
+        toTerminal: true
+      }
+    })
+
+    const routeOptions = {
+      path: '/kind',
+      method: 'GET',
+      config: {
+        response: {
+          schema: {
+            baz: Joi.object().required()
+          }
+        }
+      },
+      handler: () => {
+        return {
+          baz: 'bar'
+        }
+      }
+    }
+
+    server.route(routeOptions)
+  })
+
+  test('test if the response schema failed and no specified header', async () => {
+    const response = await server.inject({
+      url: '/kind',
+      method: 'GET'
+    })
+
+    expect(response.statusCode).to.equal(500)
+    expect(response.headers['content-type']).to.equal('application/json; charset=utf-8')
+  })
+})


### PR DESCRIPTION
First test checking if no accept content headers, plugin return HTML.
Second test making sure that when request header has `accept-content: json`, it returns `json`.
Close #5 