### PR TITLE
docs(readme): add users info

### DIFF
--- a/.github/workflows/dependents.yml
+++ b/.github/workflows/dependents.yml
@@ -1,0 +1,16 @@
+name: Dependents Action
+
+on:
+  push:
+    branches: [master]
+  schedule:
+    - cron: "0 0 1 * *"
+  workflow_dispatch:
+
+jobs:
+  dependents:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: gouravkhunger/dependents.info@0.1.3

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
     <a href="https://snyk.io/test/github/futurestudio/hapi-dev-errors"><img src="https://snyk.io/test/github/futurestudio/hapi-dev-errors/badge.svg" alt="Known Vulnerabilities" data-canonical-src="https://snyk.io/test/github/futurestudio/hapi-dev-errors" style="max-width:100%;"></a>
     <a href="https://www.npmjs.com/package/hapi-dev-errors"><img src="https://img.shields.io/npm/v/hapi-dev-errors.svg" alt="Latest Version"></a>
     <a href="https://www.npmjs.com/package/hapi-dev-errors"><img src="https://img.shields.io/npm/dm/hapi-dev-errors.svg" alt="Monthly downloads"></a>
+    <a href="https://dependents.info/futurestudio/hapi-dev-errors"><img src="https://dependents.info/futurestudio/hapi-dev-errors/badge" alt="network dependents" /></a>
   </p>
   <p>
     <em>Follow <a href="http://twitter.com/marcuspoehls">@marcuspoehls</a> for updates!</em>
@@ -45,6 +46,11 @@ Besides the web view, `hapi-dev-errors` prints pretty error details to the termi
 
 ![hapi-dev-errors pretty terminal error](media/hapi-dev-errors-on-terminal.png)
 
+## Used by
+
+<a href="https://dependents.info/futurestudio/hapi-dev-errors">
+  <img src="https://dependents.info/futurestudio/hapi-dev-errors/image" alt="users image" />
+</a>
 
 ## Requirements
 This plugin uses async/await which requires **Node.js v12 or newer**.


### PR DESCRIPTION
Hi there!

Thank you for this awesome project! I've been learning quite a bit of Hapi.js from future studio since earlier this year. Has helped me with some fun side projects!

To give back to your project, I've added a relevant auto-updated shields.io style network dependents badge and the image in the `README.md` file to showcase its impact.

I've created this using an [open source](https://github.com/gouravkhunger/dependents.info) tool I built some time ago and plan to maintain for long. It also creates an image preview of the users in the readme.

Here's how they would look for your repository:

<img width="688" alt="image" src="https://github.com/user-attachments/assets/d223ca68-befb-4072-85c9-d1b32219a9e3" />

Please feel free to close the PR if you don't want to have this!